### PR TITLE
Update Travis config and a UnitTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,9 @@ before_install:
 before_script:
   - phpenv config-rm xdebug.ini
   - echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - composer require typo3/cms=$TYPO3_VERSION -vvv --profile
+  - while true; do echo "..."; sleep 60; done &
+  - composer require typo3/cms=$TYPO3_VERSION
+  - kill %1
   - git checkout composer.json
   - export TYPO3_PATH_WEB=$PWD/.Build/Web
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
 before_script:
   - phpenv config-rm xdebug.ini
   - echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-  - composer require typo3/cms=$TYPO3_VERSION
+  - composer require typo3/cms=$TYPO3_VERSION -vvv --profile
   - git checkout composer.json
   - export TYPO3_PATH_WEB=$PWD/.Build/Web
 

--- a/Tests/Unit/Domain/Model/EventTest.php
+++ b/Tests/Unit/Domain/Model/EventTest.php
@@ -284,8 +284,8 @@ class EventTest extends UnitTestCase
      */
     public function getDaysOfEventsTakingDaysWithEqualDaysReturnsZero()
     {
-        $eventBegin = new \DateTime();
-        $eventEnd = new \DateTime();
+        $eventBegin = new \DateTime('midnight');
+        $eventEnd = new \DateTime('midnight');
         $eventEnd->modify('+20 seconds');
         $this->subject->setEventBegin($eventBegin);
         $this->subject->setEventEnd($eventEnd);

--- a/Tests/Unit/Service/DayGeneratorTest.php
+++ b/Tests/Unit/Service/DayGeneratorTest.php
@@ -416,14 +416,14 @@ class DayGeneratorTest extends UnitTestCase
     {
         // $eventBegin has to start with a month beginning with a thursday
         $eventBegin = new \DateTime('now');
-        $eventBegin->modify('first day of this month');
+        $eventBegin->modify('first day of next month');
         while ((int)$eventBegin->format('N') !== 4) {
             $eventBegin->modify('next month');
         }
         $eventBegin->modify('midnight');
         $eventBegin->modify('+16 days'); // first day of month (1) + 16 = 17. of month. Must be saturday
         $recurringEnd = clone $eventBegin;
-        $recurringEnd->modify('+22 days'); // 06th or 07th of next month. Regarding, if month has 30 or 31 days
+        $recurringEnd->modify('+22 days'); // 07th or 08th of next month. Regarding, if month has 30 or 31 days
 
         $event = new Event();
         $event->_setProperty('uid', 123);


### PR DESCRIPTION
* Add profile and verbose output to composer configured
in travis to prevent 10 minutes timeout.
* Do not run UnitTest for current month