### PR TITLE
improved find locations to search a location by any of its attributes

### DIFF
--- a/Classes/Ajax/FindLocations/Ajax.php
+++ b/Classes/Ajax/FindLocations/Ajax.php
@@ -36,43 +36,71 @@ class Ajax extends AbstractAjaxRequest
     public function processAjaxRequest(array $arguments): string
     {
         ExtensionManagementUtility::loadBaseTca(true);
-
-        // Hint: search may fail with "&" in $locationPart
-        $locationPart = (string)trim(htmlspecialchars(strip_tags($arguments['locationPart'])));
+        
+        // Hint: search may fail with "&" in $search
+        $search = (string)trim(htmlspecialchars(strip_tags($arguments['search'])));
         // keep it in sync to minLength in JS
-        if (empty($locationPart) || strlen($locationPart) <= 2) {
+        if (empty($search) || strlen($search) <= 2) {
             return '';
         } else {
-            return json_encode($this->findLocations($locationPart));
+            return json_encode($this->findLocations($search));
         }
     }
 
     /**
-     * Find locations by locationsPart.
+     * Find locations by search string.
      *
-     * @param $locationPart
+     * @param $search
      * @return array
      */
-    protected function findLocations($locationPart): array
+    protected function findLocations($search): array
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable('tx_events2_domain_model_location');
-
+        $connection = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable('tx_events2_domain_model_event');
+        
         $locations = $queryBuilder
-            ->select('uid', 'location as label')
+            ->select('uid', 'location', 'street', 'house_number', 'zip', 'city', 'country')
             ->from('tx_events2_domain_model_location')
-            ->where(
+            ->orWhere(
                 $queryBuilder->expr()->like(
                     'location',
-                    $queryBuilder->createNamedParameter('%' . $locationPart . '%', \PDO::PARAM_STR)
+                    $queryBuilder->createNamedParameter('%' . $search . '%', \PDO::PARAM_STR)
+                ),
+                $queryBuilder->expr()->like(
+                    'street',
+                    $queryBuilder->createNamedParameter('%' . $search . '%', \PDO::PARAM_STR)
+                ),
+                $queryBuilder->expr()->like(
+                    'city',
+                    $queryBuilder->createNamedParameter('%' . $search . '%', \PDO::PARAM_STR)
+                ),
+                $queryBuilder->expr()->like(
+                    'zip',
+                    $queryBuilder->createNamedParameter('%' . $search . '%', \PDO::PARAM_STR)
+                ),
+                $queryBuilder->expr()->comparison(
+                    $connection->getDatabasePlatform()->getConcatExpression('location, \' \', street, \' \', zip, \' \', city'),
+                    'LIKE',
+                    $queryBuilder->createNamedParameter('%' . $search . '%', \PDO::PARAM_STR)
                 )
             )
             ->orderBy('location', 'ASC')
             ->execute()
             ->fetchAll();
-
+        
         if (empty($locations)) {
             $locations = [];
+        }
+        foreach ($locations as &$location) {
+            $location['label'] = $location['location'];
+            if (strlen($location['street'] . $location['house_number']) > 0) {
+                $location['label'] .= ', ' . $location['street'] . ' ' . $location['house_number'];
+            }
+            if (strlen($location['zip'] . $location['city']) > 0) {
+                $location['label'] .= ', ' . $location['zip'] . ' ' . $location['city'];
+            }
         }
         return $locations;
     }

--- a/Resources/Public/JavaScript/Events2.js
+++ b/Resources/Public/JavaScript/Events2.js
@@ -202,7 +202,7 @@ Events2.initializeAutoCompleteForLocation = function() {
                     data: {
                         tx_events2_events: {
                             arguments: {
-                                locationPart: request.term
+                                search: request.term
                             }
                         }
                     },

--- a/Tests/Unit/Ajax/FindLocations/AjaxTest.php
+++ b/Tests/Unit/Ajax/FindLocations/AjaxTest.php
@@ -90,7 +90,7 @@ class AjaxTest extends UnitTestCase
     public function processAjaxRequestWithNoLocationsReturnsEmptyString()
     {
         $arguments = [
-            'locationPart' => '',
+            'search' => '',
         ];
         /** @var FindLocations\Ajax|\PHPUnit_Framework_MockObject_MockObject $subject */
         $subject = $this
@@ -110,7 +110,7 @@ class AjaxTest extends UnitTestCase
     public function processAjaxRequestWithHtmlCallsFindLocationsWithoutHtml()
     {
         $arguments = [
-            'locationPart' => 'Hello german umlauts: öäü. <b>How are you?</b>',
+            'search' => 'Hello german umlauts: öäü. <b>How are you?</b>',
         ];
         $expectedArgument = 'Hello german umlauts: öäü. How are you?';
         /** @var FindLocations\Ajax|\PHPUnit_Framework_MockObject_MockObject $subject */
@@ -131,7 +131,7 @@ class AjaxTest extends UnitTestCase
     public function processAjaxRequestWithTooSmallLocationsReturnsEmptyString()
     {
         $arguments = [
-            'locationPart' => 'x',
+            'search' => 'x',
         ];
         /** @var FindLocations\Ajax|\PHPUnit_Framework_MockObject_MockObject $subject */
         $subject = $this
@@ -182,11 +182,11 @@ class AjaxTest extends UnitTestCase
         $subject->expects($this->exactly(2))->method('findLocations')->will($this->returnValueMap($locationMap));
         $this->assertSame(
             '[{"uid":123,"label":"at home"}]',
-            $subject->processAjaxRequest(['locationPart' => 'at h'])
+            $subject->processAjaxRequest(['search' => 'at h'])
         );
         $this->assertSame(
             '[{"uid":234,"label":"Marienheide"},{"uid":345,"label":"Marienhagen"}]',
-            $subject->processAjaxRequest(['locationPart' => 'mar'])
+            $subject->processAjaxRequest(['search' => 'mar'])
         );
     }
 }


### PR DESCRIPTION
The autocomplete for finding locations in the frontend form did only search by location names.
With this PR, it is possible to search a location by any of its attributes.

Additionally, not only the location name is displayed in the autocomplete, but also the full address.