### PR TITLE
[BUGFIX] Remove tablename from exception TCA to be compatible with TYPO3 update 11.5.26 #411

### DIFF
--- a/Configuration/TCA/tx_events2_domain_model_event.php
+++ b/Configuration/TCA/tx_events2_domain_model_event.php
@@ -535,7 +535,7 @@ return [
                 'type' => 'inline',
                 'foreign_table' => 'tx_events2_domain_model_exception',
                 'foreign_field' => 'event',
-                'foreign_default_sortby' => 'tx_events2_domain_model_exception.exception_date ASC',
+                'foreign_default_sortby' => 'exception_date ASC',
                 'maxitems' => 9999,
                 'appearance' => [
                     'collapseAll' => true,


### PR DESCRIPTION
Fixed "foreign_default_sortby" in field "exceptions" of TCA tx_events2_domain_model:_event.php. (fixes #411)