### PR TITLE
[TASK] Remove deprecated softref images

### DIFF
--- a/Configuration/TCA/tx_events2_domain_model_event.php
+++ b/Configuration/TCA/tx_events2_domain_model_event.php
@@ -554,7 +554,7 @@ return [
                 'type' => 'text',
                 'cols' => 40,
                 'rows' => 15,
-                'softref' => 'typolink_tag,images,email[subst],url',
+                'softref' => 'typolink_tag,email[subst],url',
                 'enableRichtext' => true,
             ],
         ],

--- a/Configuration/TCA/tx_events2_domain_model_exception.php
+++ b/Configuration/TCA/tx_events2_domain_model_exception.php
@@ -219,7 +219,7 @@ return [
                 'cols' => 40,
                 'rows' => 15,
                 'eval' => 'trim',
-                'softref' => 'typolink_tag,images,email[subst],url',
+                'softref' => 'typolink_tag,email[subst],url',
                 'enableRichtext' => true,
             ],
         ],


### PR DESCRIPTION
With the change https://review.typo3.org/c/Packages/TYPO3.CMS/+/70177 using images in the softref config is not longer possible.

same like here https://github.com/benjaminkott/bootstrap_package/pull/1046