### PR TITLE
[BUGFIX] Make CategoryMandatoryValidator compatible

### DIFF
--- a/Classes/Domain/Validator/CategoryMandatoryValidator.php
+++ b/Classes/Domain/Validator/CategoryMandatoryValidator.php
@@ -25,7 +25,7 @@ class CategoryMandatoryValidator extends AbstractValidator
     /**
      * @param mixed $value
      */
-    public function isValid($value)
+    public function isValid($value): void
     {
         if (!$value instanceof ObjectStorage) {
             return;


### PR DESCRIPTION
Fatal error: Declaration of JWeiland\Events2\Domain\Validator\CategoryMandatoryValidator::isValid($value) must be compatible with TYPO3\CMS\Extbase\Validation\Validator\AbstractValidator::isValid(mixed $value): void in /var/www/html/app/site/vendor/jweiland/events2/Classes/Domain/Validator/CategoryMandatoryValidator.php on line 28