### PR TITLE
cast timestamp to int before process by date()

### DIFF
--- a/Classes/Utility/DateTimeUtility.php
+++ b/Classes/Utility/DateTimeUtility.php
@@ -40,7 +40,7 @@ class DateTimeUtility
                 $date = $date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
                 $dateTimeObject = $this->standardizeDateTimeObject($date);
             } else {
-                $date = new \DateTimeImmutable(date('Y-m-d H:i:s', $value));
+                $date = new \DateTimeImmutable(date('Y-m-d H:i:s', (int)$value));
                 $date = $date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
                 $dateTimeObject = $this->standardizeDateTimeObject($date);
             }


### PR DESCRIPTION
$timestamp value of `date` has been worked with string, too, but since PHP 8 it must be casted to int explizit.