### PR TITLE
Remove returnFieldJS from Time validator

### DIFF
--- a/Classes/Tca/Type/Time.php
+++ b/Classes/Tca/Type/Time.php
@@ -23,15 +23,6 @@ class Time
     public function __construct(protected readonly TimeToStringConverter $timeToStringConverter) {}
 
     /**
-     * This method returns js code to check if valid time was entered
-     * JS Validation does not work in IRRE context. So we have to validate by PHP.
-     */
-    public function returnFieldJS(): string
-    {
-        return 'return value;';
-    }
-
-    /**
      * This method converts the value into a unique time format: 21:23.
      */
     public function evaluateFieldValue(mixed $value): string


### PR DESCRIPTION
As returnFieldJS does not work in fields of IRRE elements we have just returned the old value in earlier versions. Because of some changes in core and CRSP we now have removed that method completely. The validation by PHP still exists.