### PR TITLE
[BUGFIX] Declare sys_language_uid editable for everyone

### DIFF
--- a/Configuration/TCA/tx_events2_domain_model_event.php
+++ b/Configuration/TCA/tx_events2_domain_model_event.php
@@ -80,7 +80,6 @@ return [
     ],
     'columns' => [
         'sys_language_uid' => [
-            'exclude' => true,
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.language',
             'config' => [
                 'type' => 'language',


### PR DESCRIPTION
Configuring the field as non-excludeField, will allow editors to create valid events (including their day-records).

Resolves: #528