### PR TITLE
Update def_lang_event_uid in tx_events2_domain_model_day after copy

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -121,6 +121,9 @@ ExtensionUtility::configurePlugin(
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals'][Time::class] = '';
 // delete and recreate day relations for an event while saving
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass']['events2_createDayRelations'] = Events2DataHandler::class;
+// copy events
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processCmdmapClass']['events2_createDayRelations'] = Events2DataHandler::class;
+
 // Clear the cache of pages with events if the event was edited/created/deleted in BE
 $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc']['events2_clearcache'] = Events2DataHandler::class . '->clearCachePostProc';
 


### PR DESCRIPTION
The def_lang_event_uid field must be set to the new event UID after copying, because otherwise, after saving the event record, the Day entry that has already been created will no longer be found and will therefore be recreated twice.