### PR TITLE
PHP 8.4 Fix Implicitly marking parameter as nullable is deprecated

### DIFF
--- a/Classes/Domain/Factory/ArrayFormFactory.php
+++ b/Classes/Domain/Factory/ArrayFormFactory.php
@@ -33,7 +33,7 @@ class ArrayFormFactory extends \TYPO3\CMS\Form\Domain\Factory\ArrayFormFactory
      */
     public function build(
         array $configuration,
-        string $prototypeName = null,
+        ?string $prototypeName = null,
         ?ServerRequestInterface $request = null,
     ): FormDefinition {
         $this->addEventUidToFormAction($configuration);

--- a/Classes/Domain/Repository/DayRepository.php
+++ b/Classes/Domain/Repository/DayRepository.php
@@ -341,7 +341,7 @@ class DayRepository extends Repository
     protected function addConstraintForDate(
         QueryBuilder $queryBuilder,
         string $listType,
-        QueryBuilder $parentQueryBuilder = null,
+        ?QueryBuilder $parentQueryBuilder = null,
         string $alias = 'day',
     ): void {
         $startDateTime = $this->dateTimeUtility->convert('today');

--- a/Classes/Domain/Traits/Typo3PropertiesTrait.php
+++ b/Classes/Domain/Traits/Typo3PropertiesTrait.php
@@ -55,7 +55,7 @@ trait Typo3PropertiesTrait
         return $this->_languageUid;
     }
 
-    public function setSysLanguageUid(int $sysLanguageUid = null): void
+    public function setSysLanguageUid(?int $sysLanguageUid = null): void
     {
         $this->_languageUid = $sysLanguageUid;
     }

--- a/Classes/EventListener/RestrictAccessEventListener.php
+++ b/Classes/EventListener/RestrictAccessEventListener.php
@@ -151,7 +151,7 @@ final class RestrictAccessEventListener
         $this->getFlashMessageQueue()->enqueue($flashMessage);
     }
 
-    private function getFlashMessageQueue(string $identifier = null): FlashMessageQueue
+    private function getFlashMessageQueue(?string $identifier = null): FlashMessageQueue
     {
         if ($identifier === null) {
             $pluginNamespace = $this->extensionService->getPluginNamespace(

--- a/Classes/Helper/DownloadHelper.php
+++ b/Classes/Helper/DownloadHelper.php
@@ -23,11 +23,11 @@ use TYPO3\CMS\Core\Resource\FileInterface;
 readonly class DownloadHelper
 {
     public function downloadFile(
-        FileInterface $file = null,
+        ?FileInterface $file = null,
         string $body = '',
         bool $asDownload = false,
-        string $alternativeFilename = null,
-        string $overrideMimeType = null,
+        ?string $alternativeFilename = null,
+        ?string $overrideMimeType = null,
     ): ResponseInterface {
         if ($file === null && $body === '') {
             throw new \InvalidArgumentException('Please provide either a file object or a string to download', 1639401496);
@@ -64,11 +64,11 @@ readonly class DownloadHelper
      * @throws ImmediateResponseException
      */
     public function forceDownloadFile(
-        FileInterface $file = null,
+        ?FileInterface $file = null,
         string $body = '',
         bool $asDownload = false,
-        string $alternativeFilename = null,
-        string $overrideMimeType = null,
+        ?string $alternativeFilename = null,
+        ?string $overrideMimeType = null,
     ): Response {
         throw new ImmediateResponseException(
             $this->downloadFile($file, $body, $asDownload, $alternativeFilename, $overrideMimeType),

--- a/Classes/Property/TypeConverter/DateTimeImmutableConverter.php
+++ b/Classes/Property/TypeConverter/DateTimeImmutableConverter.php
@@ -132,7 +132,7 @@ class DateTimeImmutableConverter extends AbstractTypeConverter
         $source,
         string $targetType,
         array $convertedChildProperties = [],
-        PropertyMappingConfigurationInterface $configuration = null,
+        ?PropertyMappingConfigurationInterface $configuration = null,
     ): ?object {
         $dateFormat = $this->getDefaultDateFormat($configuration);
         if (is_string($source)) {

--- a/Classes/Property/TypeConverter/UploadMultipleFilesConverter.php
+++ b/Classes/Property/TypeConverter/UploadMultipleFilesConverter.php
@@ -80,7 +80,7 @@ class UploadMultipleFilesConverter extends AbstractTypeConverter
         $source,
         string $targetType,
         array $convertedChildProperties = [],
-        PropertyMappingConfigurationInterface $configuration = null,
+        ?PropertyMappingConfigurationInterface $configuration = null,
     ): Error|ObjectStorage {
         $this->initialize($configuration);
         $filesToProcess = [];

--- a/Classes/Service/DatabaseService.php
+++ b/Classes/Service/DatabaseService.php
@@ -165,7 +165,7 @@ readonly class DatabaseService
         QueryBuilder $queryBuilder,
         \DateTimeImmutable $startDateTime,
         ?\DateTimeImmutable $endDateTime = null,
-        QueryBuilder $parentQueryBuilder = null,
+        ?QueryBuilder $parentQueryBuilder = null,
         string $alias = 'day',
     ): void {
         if ($parentQueryBuilder === null) {
@@ -202,7 +202,7 @@ readonly class DatabaseService
     public function addConstraintForPid(
         QueryBuilder $queryBuilder,
         array $storagePageIds,
-        QueryBuilder $parentQueryBuilder = null,
+        ?QueryBuilder $parentQueryBuilder = null,
         string $postAlias = '',
     ): void {
         if ($parentQueryBuilder === null) {
@@ -232,7 +232,7 @@ readonly class DatabaseService
     public function addConstraintForCategories(
         QueryBuilder $queryBuilder,
         array $categories,
-        QueryBuilder $parentQueryBuilder = null,
+        ?QueryBuilder $parentQueryBuilder = null,
         string $alias = 'event',
     ): void {
         if ($parentQueryBuilder === null) {
@@ -277,7 +277,7 @@ readonly class DatabaseService
     public function addConstraintForOrganizer(
         QueryBuilder $queryBuilder,
         int $organizer,
-        QueryBuilder $parentQueryBuilder = null,
+        ?QueryBuilder $parentQueryBuilder = null,
         string $alias = 'event',
     ): void {
         if ($parentQueryBuilder === null) {
@@ -308,7 +308,7 @@ readonly class DatabaseService
     public function addConstraintForLocation(
         QueryBuilder $queryBuilder,
         int $location,
-        QueryBuilder $parentQueryBuilder = null,
+        ?QueryBuilder $parentQueryBuilder = null,
         string $alias = 'event',
     ): void {
         if ($parentQueryBuilder === null) {
@@ -334,7 +334,7 @@ readonly class DatabaseService
         string $column,
         mixed $value,
         ParameterType $dataType = Connection::PARAM_STR,
-        QueryBuilder $parentQueryBuilder = null,
+        ?QueryBuilder $parentQueryBuilder = null,
         string $alias = 'event',
     ): void {
         if ($parentQueryBuilder === null) {

--- a/Classes/Service/Record/DayRecordService.php
+++ b/Classes/Service/Record/DayRecordService.php
@@ -245,7 +245,7 @@ readonly class DayRecordService
         return $newDayRecordKey;
     }
 
-    protected function getExistingDayRecords(int $eventUid, int $workspace = null): array
+    protected function getExistingDayRecords(int $eventUid, ?int $workspace = null): array
     {
         $schema = $this->tcaSchemaFactory->get('tx_events2_domain_model_event');
 

--- a/Classes/Service/Record/EventRecordService.php
+++ b/Classes/Service/Record/EventRecordService.php
@@ -35,7 +35,7 @@ class EventRecordService
         int $eventUid,
         bool $doVersioning = true,
         bool $doLanguageOverlay = true,
-        QueryRestrictionContainerInterface $restrictionContainer = null,
+        ?QueryRestrictionContainerInterface $restrictionContainer = null,
     ): array {
         $eventUidOfLiveVersion = $this->getLiveVersionOfEventUid($eventUid);
 
@@ -106,7 +106,7 @@ class EventRecordService
         return $sysLanguageUids;
     }
 
-    protected function getQueryBuilder(QueryRestrictionContainerInterface $restrictionContainer = null): QueryBuilder
+    protected function getQueryBuilder(?QueryRestrictionContainerInterface $restrictionContainer = null): QueryBuilder
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
 

--- a/Classes/Traits/RelationHandlerTrait.php
+++ b/Classes/Traits/RelationHandlerTrait.php
@@ -18,7 +18,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 trait RelationHandlerTrait
 {
-    private function createRelationHandlerInstance(int $workspace = null): RelationHandler
+    private function createRelationHandlerInstance(?int $workspace = null): RelationHandler
     {
         $isWorkspacesLoaded = ExtensionManagementUtility::isLoaded('workspaces');
 

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -144,6 +144,10 @@
 				<target>Zum Ticketverkauf</target>
 			</trans-unit>
 			<trans-unit id="tx_events2_domain_model_event.attendance_mode">
+				<source>Attendance Mode</source>
+				<target>Durchführungsform</target>
+			</trans-unit>
+			<trans-unit id="tx_events2_domain_model_event.attendance_mode.empty">
 				<source>Not specified</source>
 				<target>Keine Angabe</target>
 			</trans-unit>


### PR DESCRIPTION
Added explicit nullable type declarations to method signatures across the extension. Relying on the default value null to implicitly mark a type as nullable is deprecated in PHP 8.4+.

Also added a fix for "tx_events2_domain_model_event.attendance_mode" for de.locallang.xlf - otherwise it would be "Keine Angabe" as heading 😉