### PR TITLE
[BUGFIX] Resolve selectable categories in editAction like newAction

### DIFF
--- a/Classes/Controller/ManagementController.php
+++ b/Classes/Controller/ManagementController.php
@@ -121,9 +121,17 @@ class ManagementController extends AbstractController
     #[Extbase\IgnoreValidation(['value' => 'event'])]
     public function editAction(Event $event): ResponseInterface
     {
-        $categories = $this->categoryRepository->getCategories(
-            $this->settings['selectableCategoriesForNewEvents'],
-        );
+        if (isset($this->settings['selectableCategoriesForNewEvents'])) {
+            trigger_error(
+                'settings.selectableCategoriesForNewEvents is deprecated. Please of settings.new.selectableCategoriesForNewEvents instead.',
+                E_USER_DEPRECATED,
+            );
+            $selectableCategories = $this->settings['new']['selectableCategoriesForNewEvents'] ?? $this->settings['selectableCategoriesForNewEvents'];
+        } else {
+            $selectableCategories = $this->settings['new']['selectableCategoriesForNewEvents'];
+        }
+
+        $categories = $this->categoryRepository->getCategories($selectableCategories);
 
         if ($categories->count() === 0) {
             $this->addFlashMessage('Dear Admin: You have forgotten to define some allowed categories in plugin configuration');


### PR DESCRIPTION
Fixes #616.

`editAction` still read the deprecated flat `settings.selectableCategoriesForNewEvents` key directly, so configuring only `settings.new.selectableCategoriesForNewEvents` left the flat key undefined and produced the "Undefined array key" warning at line 125 on PHP 8. `newAction` already resolves this correctly, so this reuses the same logic (new location first, deprecated key as fallback) in `editAction`.

I could not run the functional controller suite here since it needs a full TYPO3 frontend request with a logged-in user and an existing event, but the change is a direct mirror of the resolution `newAction` already uses.