### PR TITLE
[BUGFIX] Render teaser/detailInformation as plain text

### DIFF
--- a/Classes/Domain/Finisher/SaveEventFinisher.php
+++ b/Classes/Domain/Finisher/SaveEventFinisher.php
@@ -296,11 +296,11 @@ class SaveEventFinisher extends AbstractFinisher
 
         $paragraphs = array_filter(
             array_map('trim', preg_split('/\n{2,}/', trim($plainText)) ?: []),
-            static fn (string $paragraph): bool => $paragraph !== '',
+            static fn(string $paragraph): bool => $paragraph !== '',
         );
 
         return implode('', array_map(
-            static fn (string $paragraph): string => '<p>' . nl2br(htmlspecialchars($paragraph, ENT_QUOTES | ENT_HTML5)) . '</p>',
+            static fn(string $paragraph): string => '<p>' . nl2br(htmlspecialchars($paragraph, ENT_QUOTES | ENT_HTML5)) . '</p>',
             $paragraphs,
         ));
     }

--- a/Classes/Domain/Finisher/SaveEventFinisher.php
+++ b/Classes/Domain/Finisher/SaveEventFinisher.php
@@ -273,12 +273,36 @@ class SaveEventFinisher extends AbstractFinisher
             } elseif ($elementValue instanceof \DateTimeInterface) {
                 $format = $elementsConfiguration[$elementIdentifier]['dateFormat'] ?? 'U';
                 $elementValue = $elementValue->format($format);
+            } elseif ($elementsConfiguration[$elementIdentifier]['convertPlainTextToHtml'] ?? false) {
+                $elementValue = $this->convertPlainTextToHtml((string)$elementValue);
             }
 
             $databaseData[$elementsConfiguration[$elementIdentifier]['mapOnDatabaseColumn']] = $elementValue;
         }
 
         return $databaseData;
+    }
+
+    /**
+     * There is no RTE for this element in frontend. A single line break is meant as <br>,
+     * an empty line between two blocks of text is meant as a new paragraph. Any tag the
+     * visitor might have typed or pasted in is removed beforehand, so only our own <p> and
+     * <br> tags end up in the database.
+     */
+    protected function convertPlainTextToHtml(string $plainText): string
+    {
+        $plainText = strip_tags($plainText);
+        $plainText = str_replace(["\r\n", "\r"], "\n", $plainText);
+
+        $paragraphs = array_filter(
+            array_map('trim', preg_split('/\n{2,}/', trim($plainText)) ?: []),
+            static fn (string $paragraph): bool => $paragraph !== '',
+        );
+
+        return implode('', array_map(
+            static fn (string $paragraph): string => '<p>' . nl2br(htmlspecialchars($paragraph, ENT_QUOTES | ENT_HTML5)) . '</p>',
+            $paragraphs,
+        ));
     }
 
     protected function saveDataForCategories(array $databaseData, string $table, int $iterationCount): array

--- a/Classes/ViewHelpers/ConvertHtmlToPlainTextViewHelper.php
+++ b/Classes/ViewHelpers/ConvertHtmlToPlainTextViewHelper.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package jweiland/events2.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace JWeiland\Events2\ViewHelpers;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * There is no RTE for teaser/detailInformation in frontend, so any markup in there either comes
+ * from a backend editor using the RTE, or from SaveEventFinisher::convertPlainTextToHtml(), which
+ * only ever produces <p> and <br> tags. This ViewHelper turns </p> and <br> back into real line
+ * breaks, strips every other tag along with its markup (keeping its text content), and escapes the
+ * result. Chain it with f:format.nl2br to get visible line breaks again.
+ */
+final class ConvertHtmlToPlainTextViewHelper extends AbstractViewHelper
+{
+    /**
+     * No output escaping, as we build our own htmlspecialchars-escaped text.
+     */
+    protected $escapeOutput = false;
+
+    /**
+     * The value must reach render() unescaped, else strip_tags() below has
+     * nothing left to strip.
+     */
+    protected $escapeChildren = false;
+
+    public function initializeArguments(): void
+    {
+        $this->registerArgument('value', 'string', 'The HTML formatted value to convert to plain text', false, null);
+    }
+
+    public function render(): string
+    {
+        $value = $this->arguments['value'] ?? $this->renderChildren();
+        if (!is_string($value) || trim($value) === '') {
+            return '';
+        }
+
+        $value = str_replace(["\r\n", "\r"], "\n", $value);
+        $value = (string)preg_replace('/<\/p\s*>/i', "\n\n", $value);
+        $value = (string)preg_replace('/<br\s*\/?>/i', "\n", $value);
+        $value = strip_tags($value);
+
+        // RTE editors leave a raw newline between tags in the stored HTML. Collapse any run of
+        // blank lines, whether it came from that raw whitespace or from a genuine paragraph break
+        // above, into a single blank line.
+        $value = (string)preg_replace('/\n[ \t]*\n+/', "\n\n", $value);
+
+        return htmlspecialchars(trim($value), ENT_QUOTES | ENT_HTML5);
+    }
+}

--- a/Configuration/Form/NewEvent.form.yaml
+++ b/Configuration/Form/NewEvent.form.yaml
@@ -609,8 +609,10 @@ finishers:
             mapOnDatabaseColumn: title
           short-description:
             mapOnDatabaseColumn: teaser
+            convertPlainTextToHtml: true
           detail-description:
             mapOnDatabaseColumn: detail_information
+            convertPlainTextToHtml: true
           event-begin:
             mapOnDatabaseColumn: event_begin
             dateFormat: U

--- a/Resources/Private/Partials/Day/Properties.html
+++ b/Resources/Private/Partials/Day/Properties.html
@@ -8,8 +8,8 @@
         <h1>{day.event.title}</h1>
         <f:render section="RenderImages" arguments="{event: day.event}"/>
         <f:render section="VideoLink" arguments="{event: day.event}"/>
-        <p class="lead">{day.event.teaser}</p>
-        <f:format.html>{day.event.detailInformation}</f:format.html>
+        <p class="lead">{day.event.teaser -> e2:convertHtmlToPlainText() -> f:format.nl2br()}</p>
+        <p>{day.event.detailInformation -> e2:convertHtmlToPlainText() -> f:format.nl2br()}</p>
         <f:render section="DownloadLinks" arguments="{event: day.event}"/>
     </div>
     <div class="col-md-3">

--- a/Resources/Private/Partials/Event/List.html
+++ b/Resources/Private/Partials/Event/List.html
@@ -21,7 +21,7 @@
             <f:render section="Title" arguments="{day: day}"/>
 
             <f:if condition="{day.event.teaser}">
-                <p>{day.event.teaser}</p>
+                <p>{day.event.teaser -> e2:convertHtmlToPlainText() -> f:format.nl2br()}</p>
             </f:if>
         </li>
     </f:for>

--- a/Resources/Private/Partials/Event/Teaser.html
+++ b/Resources/Private/Partials/Event/Teaser.html
@@ -1,9 +1,10 @@
 <html lang="en"
       xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:e2="http://typo3.org/ns/JWeiland/Events2/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
 <f:if condition="{event.teaser}">
-    <f:then><p>{event.teaser -> f:format.html(parseFuncTSPath: 'lib.parseFunc') -> f:format.nl2br()}</p></f:then>
-    <f:else><p>{event.detailInformation -> f:format.crop(maxCharacters: 100) -> f:format.html(parseFuncTSPath:'lib.parseFunc') -> f:format.nl2br()}</p></f:else>
+    <f:then><p>{event.teaser -> e2:convertHtmlToPlainText() -> f:format.nl2br()}</p></f:then>
+    <f:else><p>{event.detailInformation -> e2:convertHtmlToPlainText() -> f:format.crop(maxCharacters: 100) -> f:format.nl2br()}</p></f:else>
 </f:if>
 </html>

--- a/Resources/Private/Templates/Management/Create.html
+++ b/Resources/Private/Templates/Management/Create.html
@@ -1,3 +1,4 @@
+{namespace e2=JWeiland\Events2\ViewHelpers}
 <p>Hallo,</p>
 
 <p>
@@ -20,11 +21,11 @@
     </tr>
     <tr>
         <td><f:translate key="tx_events2_domain_model_event.teaser"/></td>
-        <td>{event.teaser}</td>
+        <td>{event.teaser -> e2:convertHtmlToPlainText() -> f:format.nl2br()}</td>
     </tr>
     <tr>
         <td><f:translate key="tx_events2_domain_model_event.detail_information"/></td>
-        <td>{event.detailInformation}</td>
+        <td>{event.detailInformation -> e2:convertHtmlToPlainText() -> f:format.nl2br()}</td>
     </tr>
     <tr>
         <td><f:translate key="tx_events2_domain_model_event.event_begin"/></td>

--- a/Resources/Private/Templates/Management/Update.html
+++ b/Resources/Private/Templates/Management/Update.html
@@ -1,3 +1,4 @@
+{namespace e2=JWeiland\Events2\ViewHelpers}
 <p>Hallo,</p>
 
 <p>
@@ -20,11 +21,11 @@
     </tr>
     <tr>
         <td><f:translate key="tx_events2_domain_model_event.teaser"/></td>
-        <td>{event.teaser}</td>
+        <td>{event.teaser -> e2:convertHtmlToPlainText() -> f:format.nl2br()}</td>
     </tr>
     <tr>
         <td><f:translate key="tx_events2_domain_model_event.detail_information"/></td>
-        <td>{event.detailInformation}</td>
+        <td>{event.detailInformation -> e2:convertHtmlToPlainText() -> f:format.nl2br()}</td>
     </tr>
     <tr>
         <td><f:translate key="tx_events2_domain_model_event.event_begin"/></td>


### PR DESCRIPTION
## Summary

There is no RTE for `teaser`/`detailInformation` in the frontend EXT:form. Any markup in these two fields therefore comes either from a backend editor using the RTE (`detail_information` has `enableRichtext: true` in TCA), or from raw text a visitor typed or pasted into the plain `Textarea` element. Depending on the template, that value was previously rendered with `f:format.html` (parsing arbitrary editor HTML uncontrolled - bold, links, anything the RTE allows, ends up live on the page) or with Fluid's default escaping (showing literal `<p>` tags as visible text).

- Add `Classes/ViewHelpers/ConvertHtmlToPlainTextViewHelper.php`: converts `</p>` and `<br>` back into real line breaks, strips every other tag along with its markup (keeping the tag's text content), normalizes `\r\n`, collapses any resulting run of blank lines into one, and escapes the result. Meant to be chained with `f:format.nl2br()`.
- Wire it into `Day/Properties.html`, `Event/Teaser.html`, `Event/List.html` and the `Management/Create.html`/`Update.html` notification emails, replacing the previous `f:format.html`/plain-output usages.
- On the save side, `SaveEventFinisher::prepareData()` gets a new per-element option `convertPlainTextToHtml`. When enabled for `detail-description`/`short-description`, a single line break becomes `<br>`, a blank line becomes a new `<p>` paragraph, and `strip_tags()` runs on the raw input first, so nothing a visitor typed or pasted survives into the database except our own `<p>`/`<br>`. This is enabled in `Configuration/Form/NewEvent.form.yaml` for both fields.

Net effect: any formatting a backend editor added (bold, italic, links) is simply gone on the frontend - by design, since there is no way for a frontend visitor to produce or edit that formatting. Paragraph and line breaks are preserved either way.

## Test plan

- [x] Verified against a real backend-RTE-authored event record (`<p>`, multiple paragraphs with a raw `\r\n\r\n` between the closing/opening tag) - renders as clean paragraphs with a single blank line between them, no visible tags.
- [x] Verified the escaping path in isolation against the exact stored bytes (quotes render literally, no double-escaping).
- [ ] Maintainer review: confirm dropping backend-added inline formatting (bold/links) on the frontend is the intended behaviour rather than a regression for existing content.
- [ ] End-to-end test of a full frontend submission through `SaveEventFinisher` with multi-line/multi-paragraph input, once that flow is otherwise working end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)