### PR TITLE
[BUGFIX] Suppress redundant generic error flash message

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -163,6 +163,21 @@ class AbstractController extends ActionController implements LoggerAwareInterfac
         return $response->withStatus(400);
     }
 
+    /**
+     * RestrictAccessEventListener already adds a specific, localized flash message (e.g.
+     * "missing organizer", "unauthorized organizer") before forwarding to this action. The
+     * default Extbase message ("An error occurred while trying to call ...->errorAction()")
+     * would just add confusing, redundant noise on top of that.
+     */
+    protected function getErrorFlashMessage(): bool|string
+    {
+        if ($this->getFlashMessageQueue()->getAllMessages() !== []) {
+            return false;
+        }
+
+        return parent::getErrorFlashMessage();
+    }
+
     protected function postProcessAndAssignFluidVariables(array $variables = []): void
     {
         /** @var PostProcessFluidVariablesEvent $event */


### PR DESCRIPTION
## Summary

Reported symptom: a frontend user without a matching organizer relation, trying to edit an event via the Management plugin, sees "An error occurred while trying to call JWeiland\Events2\Controller\ManagementController->errorAction()" - reads like a crash, but nothing is ever logged as an exception/error (also not visible in Sentry), because it isn't one.

`RestrictAccessEventListener::isAccessAllowed()` denies access and adds its own specific, localized flash message (missing organizer, unauthorized organizer, missing user group, login required) before forwarding the request to `errorAction()`. `AbstractController::errorAction()` then unconditionally calls `addErrorFlashMessage()`, which enqueues Extbase's own generic fallback message (`getErrorFlashMessage()` default implementation: `'An error occurred while trying to call ' . static::class . '->' . $this->actionMethodName . '()'`) on top of the specific one already queued. The user ends up seeing two stacked flash messages, the second of which reads like a technical crash.

Fix: override `getErrorFlashMessage()` to return `false` when the plugin's flash message queue already holds a message, so the generic fallback only shows up when nothing more specific was set (e.g. genuine Extbase argument validation failures still get *some* message).

One subtlety: `FlashMessageQueue::enqueue()` diverts session-stored messages (the default, `storeInSession: true`) straight into `addFlashMessageToSession()` rather than the in-memory `\SplQueue` it extends - so `FlashMessageQueue::count()` is always `0` for these and can't be used to detect them. `getAllMessages()` merges session + in-memory messages non-destructively, which is what the fix uses.

## Reproduction / Test plan

- [x] FE user without any `tx_events2_organizer` set, opening an event edit link → only the specific "missing organizer" flash message is shown now (previously: that message plus the generic "error occurred" one).
- [x] FE user with an organizer that isn't assigned to the requested event → same, only the specific "unauthorized organizer" message.
- [x] FE user with a matching organizer → unaffected, edit form loads normally.
- [ ] Maintainer review: confirm suppressing the generic message whenever *any* flash message is already queued is the right condition, rather than something more targeted to `RestrictAccessEventListener` specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)