### PR TITLE
[TASK] Add missing tests and ChangeLog entries for recent bugfixes

### DIFF
--- a/Documentation/ChangeLog/Index.rst
+++ b/Documentation/ChangeLog/Index.rst
@@ -11,6 +11,8 @@ Version 10.2.9
 ==============
 
 *   [BUGFIX] Resolve location label in event edit form
+*   [BUGFIX] Render teaser/detailInformation as plain text
+*   [BUGFIX] Suppress redundant generic error flash message
 
 Version 10.2.8
 ==============

--- a/Tests/Functional/Controller/ManagementControllerTest.php
+++ b/Tests/Functional/Controller/ManagementControllerTest.php
@@ -99,6 +99,10 @@ class ManagementControllerTest extends FunctionalTestCase
             'This page is restricted. Please log in to access the Events Management area.',
             $content,
         );
+        self::assertStringNotContainsString(
+            'An error occurred while trying to call',
+            $content,
+        );
     }
 
     #[Test]
@@ -115,6 +119,10 @@ class ManagementControllerTest extends FunctionalTestCase
             'You\'re not allowed to create event records',
             $content,
         );
+        self::assertStringNotContainsString(
+            'An error occurred while trying to call',
+            $content,
+        );
     }
 
     #[Test]
@@ -129,6 +137,10 @@ class ManagementControllerTest extends FunctionalTestCase
 
         self::assertStringContainsString(
             'You\'re allowed to create event records, but your user record has no relation to an organizer record.',
+            $content,
+        );
+        self::assertStringNotContainsString(
+            'An error occurred while trying to call',
             $content,
         );
     }

--- a/Tests/Functional/Hook/PrefillForEditUsageHookTest.php
+++ b/Tests/Functional/Hook/PrefillForEditUsageHookTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package jweiland/events2.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace JWeiland\Events2\Tests\Functional\Hook;
+
+use JWeiland\Events2\Hook\Form\PrefillForEditUsageHook;
+use JWeiland\Events2\Tests\Functional\Events2Constants;
+use JWeiland\Events2\Tests\Functional\Traits\InsertEventTrait;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Domain\Repository\PageRepository;
+use TYPO3\CMS\Form\Domain\Model\FormDefinition;
+use TYPO3\CMS\Form\Domain\Model\FormElements\GenericFormElement;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Functional test for PrefillForEditUsageHook
+ */
+class PrefillForEditUsageHookTest extends FunctionalTestCase
+{
+    use InsertEventTrait;
+
+    protected array $coreExtensionsToLoad = [
+        'extensionmanager',
+        'form',
+        'reactions',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
+        'jweiland/events2',
+    ];
+
+    protected array $configurationToUseInTestInstance = [
+        'SYS' => [
+            'phpTimeZone' => Events2Constants::PHP_TIMEZONE,
+        ],
+    ];
+
+    protected PrefillForEditUsageHook $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Events2PageTree.csv');
+
+        $this->subject = new PrefillForEditUsageHook(
+            $this->get(PageRepository::class),
+        );
+    }
+
+    #[Test]
+    public function setFormDefaultValuesWithColumnAndRelationKeepsUidAsDefaultValueAndResolvesLabel(): void
+    {
+        $eventUid = $this->insertEvent(
+            title: 'Event with location',
+            eventBegin: new \DateTimeImmutable('today midnight'),
+            location: 'Marketplace',
+        );
+        $eventRecord = $this->getEventRecord($eventUid);
+
+        $formElement = $this->buildFormElement('location', [
+            'dbMapping' => [
+                'column' => 'location',
+                'relation' => [
+                    'table' => 'tx_events2_domain_model_location',
+                    'labelColumn' => 'location',
+                    'expressions' => [
+                        [
+                            'column' => 'uid',
+                            'expression' => 'eq',
+                            'value' => '{event:location}',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->callSetFormDefaultValues($formElement, $eventRecord);
+
+        self::assertSame(
+            $eventRecord['location'],
+            $formElement->getDefaultValue(),
+        );
+        self::assertSame(
+            'Marketplace',
+            $formElement->getProperties()['resolvedLabel'],
+        );
+    }
+
+    #[Test]
+    public function setFormDefaultValuesWithoutRelationDoesNotSetResolvedLabel(): void
+    {
+        $eventUid = $this->insertEvent(
+            title: 'Event without relation config',
+            eventBegin: new \DateTimeImmutable('today midnight'),
+            location: 'Marketplace',
+        );
+        $eventRecord = $this->getEventRecord($eventUid);
+
+        $formElement = $this->buildFormElement('location', [
+            'dbMapping' => [
+                'column' => 'location',
+            ],
+        ]);
+
+        $this->callSetFormDefaultValues($formElement, $eventRecord);
+
+        self::assertSame(
+            $eventRecord['location'],
+            $formElement->getDefaultValue(),
+        );
+        self::assertArrayNotHasKey(
+            'resolvedLabel',
+            $formElement->getProperties(),
+        );
+    }
+
+    #[Test]
+    public function getLabelWithMissingRelationRecordReturnsEmptyString(): void
+    {
+        $eventUid = $this->insertEvent(
+            title: 'Event without location',
+            eventBegin: new \DateTimeImmutable('today midnight'),
+        );
+        $eventRecord = $this->getEventRecord($eventUid);
+
+        $formElement = $this->buildFormElement('location', [
+            'dbMapping' => [
+                'column' => 'location',
+                'relation' => [
+                    'table' => 'tx_events2_domain_model_location',
+                    'labelColumn' => 'location',
+                    'expressions' => [
+                        [
+                            'column' => 'uid',
+                            'expression' => 'eq',
+                            'value' => '{event:location}',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->callSetFormDefaultValues($formElement, $eventRecord);
+
+        self::assertSame(
+            $eventRecord['location'],
+            $formElement->getDefaultValue(),
+        );
+        self::assertSame(
+            '',
+            $formElement->getProperties()['resolvedLabel'],
+        );
+    }
+
+    private function buildFormElement(string $identifier, array $properties): GenericFormElement
+    {
+        $formDefinition = new FormDefinition('test-form');
+        $formElement = new GenericFormElement($identifier, 'Events2Location');
+        $formElement->setParentRenderable($formDefinition);
+
+        foreach ($properties as $key => $value) {
+            $formElement->setProperty($key, $value);
+        }
+
+        return $formElement;
+    }
+
+    private function callSetFormDefaultValues(GenericFormElement $formElement, array $eventRecord): void
+    {
+        $method = new \ReflectionMethod($this->subject, 'setFormDefaultValues');
+        $method->invoke($this->subject, $formElement, $eventRecord);
+    }
+
+    private function getEventRecord(int $eventUid): array
+    {
+        $connection = $this->getConnectionPool()->getConnectionForTable('tx_events2_domain_model_event');
+
+        return $connection->select(['*'], 'tx_events2_domain_model_event', ['uid' => $eventUid])
+            ->fetchAssociative();
+    }
+}

--- a/Tests/Functional/ViewHelpers/ConvertHtmlToPlainTextViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/ConvertHtmlToPlainTextViewHelperTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package jweiland/events2.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace JWeiland\Events2\Tests\Functional\ViewHelpers;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextFactory;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+use TYPO3Fluid\Fluid\View\TemplateView;
+
+/**
+ * Functional test for ConvertHtmlToPlainTextViewHelper using TYPO3 13+ RenderingContext
+ */
+class ConvertHtmlToPlainTextViewHelperTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'extensionmanager',
+        'reactions',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'sjbr/static-info-tables',
+        'jweiland/events2',
+    ];
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function htmlDataProvider(): array
+    {
+        return [
+            'Empty string stays empty' => [
+                '',
+                '',
+            ],
+            'Plain text without tags stays untouched' => [
+                'Hello world',
+                'Hello world',
+            ],
+            'Closing paragraph tag becomes a blank line' => [
+                '<p>First paragraph</p><p>Second paragraph</p>',
+                "First paragraph\n\nSecond paragraph",
+            ],
+            'Br tag becomes a line break' => [
+                'Hello<br />world',
+                "Hello\nworld",
+            ],
+            'Self-closing br tag becomes a line break' => [
+                'Hello<br/>world',
+                "Hello\nworld",
+            ],
+            'Formatting tags are stripped but their text survives' => [
+                '<p><b>Bold</b> and <a href="https://example.com">a link</a></p>',
+                'Bold and a link',
+            ],
+            'Script tag markup is stripped, its text content remains but is escaped' => [
+                '<script>alert("xss")</script>Hello',
+                'alert(&quot;xss&quot;)Hello',
+            ],
+            'Special characters are escaped' => [
+                '<p>Tom & Jerry "quoted"</p>',
+                'Tom &amp; Jerry &quot;quoted&quot;',
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('htmlDataProvider')]
+    public function renderConvertsHtmlToEscapedPlainText(string $inputValue, string $expectedPlainText): void
+    {
+        $context = $this->get(RenderingContextFactory::class)->create();
+        $context->getVariableProvider()->add('inputValue', $inputValue);
+
+        $templateSource = '
+            {namespace e2=JWeiland\Events2\ViewHelpers}
+            <f:format.raw>{inputValue -> e2:convertHtmlToPlainText()}</f:format.raw>';
+
+        $context->getTemplatePaths()->setTemplateSource($templateSource);
+
+        $view = new TemplateView($context);
+        $output = trim($view->render());
+
+        self::assertSame(
+            $expectedPlainText,
+            $output,
+        );
+    }
+}

--- a/Tests/Unit/Domain/Finisher/SaveEventFinisherTest.php
+++ b/Tests/Unit/Domain/Finisher/SaveEventFinisherTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package jweiland/events2.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace JWeiland\Events2\Tests\Unit\Domain\Finisher;
+
+use JWeiland\Events2\Domain\Finisher\SaveEventFinisher;
+use JWeiland\Events2\Helper\PathSegmentHelper;
+use JWeiland\Events2\Service\DayRelationService;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Test case.
+ */
+class SaveEventFinisherTest extends UnitTestCase
+{
+    protected SaveEventFinisher $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new SaveEventFinisher(
+            self::createStub(ConnectionPool::class),
+            self::createStub(PathSegmentHelper::class),
+            self::createStub(DayRelationService::class),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->subject);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function convertPlainTextToHtmlWithEmptyStringReturnsEmptyString(): void
+    {
+        self::assertSame(
+            '',
+            $this->convertPlainTextToHtml(''),
+        );
+    }
+
+    #[Test]
+    public function convertPlainTextToHtmlWithSingleLineWrapsItInParagraph(): void
+    {
+        self::assertSame(
+            '<p>Hello world</p>',
+            $this->convertPlainTextToHtml('Hello world'),
+        );
+    }
+
+    #[Test]
+    public function convertPlainTextToHtmlWithSingleLineBreakConvertsItToBrTag(): void
+    {
+        self::assertSame(
+            "<p>Hello<br />\nworld</p>",
+            $this->convertPlainTextToHtml("Hello\nworld"),
+        );
+    }
+
+    #[Test]
+    public function convertPlainTextToHtmlWithBlankLineStartsNewParagraph(): void
+    {
+        self::assertSame(
+            '<p>First paragraph</p><p>Second paragraph</p>',
+            $this->convertPlainTextToHtml("First paragraph\n\nSecond paragraph"),
+        );
+    }
+
+    #[Test]
+    public function convertPlainTextToHtmlWithWindowsLineEndingsIsTreatedLikeUnixLineEndings(): void
+    {
+        self::assertSame(
+            '<p>First paragraph</p><p>Second paragraph</p>',
+            $this->convertPlainTextToHtml("First paragraph\r\n\r\nSecond paragraph"),
+        );
+    }
+
+    #[Test]
+    public function convertPlainTextToHtmlStripsTagsTypedOrPastedByVisitor(): void
+    {
+        self::assertSame(
+            '<p>alert(&quot;xss&quot;)bold text</p>',
+            $this->convertPlainTextToHtml('<script>alert("xss")</script><b>bold text</b>'),
+        );
+    }
+
+    #[Test]
+    public function convertPlainTextToHtmlEscapesSpecialCharacters(): void
+    {
+        self::assertSame(
+            '<p>Tom &amp; Jerry &quot;quoted&quot;</p>',
+            $this->convertPlainTextToHtml('Tom & Jerry "quoted"'),
+        );
+    }
+
+    private function convertPlainTextToHtml(string $plainText): string
+    {
+        $method = new \ReflectionMethod($this->subject, 'convertPlainTextToHtml');
+
+        return $method->invoke($this->subject, $plainText);
+    }
+}


### PR DESCRIPTION
## Summary
- Commits #626, #627 and #628 shipped without dedicated test coverage; #627 and #628 were also missing from the ChangeLog.
- Added `SaveEventFinisherTest` (Unit) for `convertPlainTextToHtml()`.
- Added `ConvertHtmlToPlainTextViewHelperTest` (Functional) for the new ViewHelper.
- Added `PrefillForEditUsageHookTest` (Functional) covering the new `relation`/`resolvedLabel` handling (column value stays untouched, label gets resolved, empty case handled).
- Extended the existing `ManagementControllerTest` error-page tests with an assertion that the generic Extbase error message no longer duplicates the specific `RestrictAccessEventListener` message (verified this assertion fails without the #628 fix).
- Documented #627 and #628 in `Documentation/ChangeLog/Index.rst` under the already-bumped Version 10.2.9 (version number left untouched).

## Test plan
- [x] `Build/Scripts/runTests.sh -s unit -p 8.4` — 323 tests, all green
- [x] `Build/Scripts/runTests.sh -s functional -p 8.4 -d sqlite` — 296 tests, all green
- [x] `Build/Scripts/runTests.sh -s cgl -p 8.4` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)